### PR TITLE
Add support for https server with local certs

### DIFF
--- a/bin/skilt.js
+++ b/bin/skilt.js
@@ -3,10 +3,11 @@
 const extras = require('extras')
 
 const command = process.argv[2]
+const args = process.argv.slice(3)
 
 function usage() {
   console.log('Usage:\n')
-  console.log('  skilt start - start web proxy')
+  console.log('  skilt start [--https | -h] - start web proxy')
   console.log('  skilt stop  - stop web proxy')
   process.exit(0)
 }
@@ -14,6 +15,8 @@ function usage() {
 if (!command) usage()
 
 if (command == 'start') {
+  const useHttps = args.includes('--https') || args.includes('-h')
+  process.env.SKILT_HTTPS = useHttps ? 'true' : 'false'
   require('../index.js')
 } else if (command == 'stop') {
   extras.run(`kill -9 $(pgrep -f bin/skilt)`)


### PR DESCRIPTION
## Summary

Adds optional HTTPS support to the proxy server using local certificates stored at `~/.config/skilt`.

- Adds `--https` / `-h` flag to `skilt start`
- Loads certificates from `~/.config/skilt/{localhost.key, localhost.cert}`
- Logs helpful errors if cert files are missing
- Defaults to HTTP if the flag is not provided

## Usage

To be able to use the HTTPS server, the local certificates has to be created and stored on the *config/skilt* dir first.

```bash
cd ~/.config/skilt
openssl req -x509 -newkey rsa:4096 -keyout localhost.key -out localhost.cert -days 365 -nodes -subj "/CN=localhost"
```

Once the **localhost.key** and the **localhost.cert** files are created, the HTTPS server can be started like this

```bash
skilt start --https
```

or like this

```bash
skilt start -h
```